### PR TITLE
5 최근 거래정보의 직전 거래 정보를 제공하는 기능 추가

### DIFF
--- a/back/src/application/interface/LocationFormRepository.js
+++ b/back/src/application/interface/LocationFormRepository.js
@@ -26,6 +26,11 @@ module.exports = class {
         throw new Error('ERR_METHOD_NOT_IMPLEMENTED');
     }
 
+    async findProviousOfRecentlyDeals(coordinate, ssg_cd) {
+        // coordinate = {min_x,min_y,max_x,max_y}
+        throw new Error('ERR_METHOD_NOT_IMPLEMENTED');
+    }
+
     async findMaxOne(attribute, sgg_cd) {
         // only [int,float] type attribute is available
         throw new Error('ERR_METHOD_NOT_IMPLEMENTED');

--- a/back/src/application/service/locationForm.js
+++ b/back/src/application/service/locationForm.js
@@ -24,6 +24,22 @@ module.exports = class {
         }
     }
 
+    async findProviousOfRecentlyDeals(coordinate, locationList) {
+        try {
+            let result = [];
+
+            const promises = locationList.map(async (info) => {
+                const sgg_cd = info.sgg_cd;
+                const deals = await this.repository.findProviousOfRecentlyDeals(coordinate, sgg_cd)
+                result = result.concat(deals);
+            })
+            await Promise.all(promises);
+            return result;
+        } catch (error) {
+            RESPONSE.errorCheckAndloggingThenThrow(error, RESPONSE.DB_FIND_ERROR);
+        }
+    }
+
     async findMaxMinCoordinate(sgg_cd) {
         try {
             const max_x = await this.repository.findMaxOne('x', sgg_cd);

--- a/back/src/application/service/locationForm.js
+++ b/back/src/application/service/locationForm.js
@@ -26,15 +26,19 @@ module.exports = class {
 
     async findProviousOfRecentlyDeals(coordinate, locationList) {
         try {
-            let result = [];
+            let resultRecent = [];
+            let resultProvious = [];
 
             const promises = locationList.map(async (info) => {
                 const sgg_cd = info.sgg_cd;
-                const deals = await this.repository.findProviousOfRecentlyDeals(coordinate, sgg_cd)
-                result = result.concat(deals);
+                const dealsRecent = await this.repository.findRecentlyDeals(coordinate, sgg_cd)
+                resultRecent = resultRecent.concat(dealsRecent);
+
+                const dealsProvious = await this.repository.findProviousOfRecentlyDeals(coordinate, sgg_cd)
+                resultProvious = resultProvious.concat(dealsProvious);
             })
             await Promise.all(promises);
-            return result;
+            return { resultRecent, resultProvious };
         } catch (error) {
             RESPONSE.errorCheckAndloggingThenThrow(error, RESPONSE.DB_FIND_ERROR);
         }

--- a/back/src/controllers/displayDealsController.js
+++ b/back/src/controllers/displayDealsController.js
@@ -7,8 +7,8 @@ const LocationFormRepository = require('../infrastructure/database/repositories/
 const RESPONSE = require('../config/responseState');
 
 exports.RecentlyDeals = async (options) => {
-    const locationService = new LocationService(options.locationRepository || new LocationRepository());
-    const locationFormService = new LocationFormService(options.locationFormRepository || new LocationFormRepository());
+    const locationService = new LocationService(options.locationRepository);
+    const locationFormService = new LocationFormService(options.locationFormRepository);
     const coordinate = {
         min_x: options.body.bounds.min.x,
         min_y: options.body.bounds.min.y,

--- a/back/src/controllers/displayDealsController.js
+++ b/back/src/controllers/displayDealsController.js
@@ -6,7 +6,7 @@ const LocationFormRepository = require('../infrastructure/database/repositories/
 
 const RESPONSE = require('../config/responseState');
 
-exports.basic = async (options) => {
+exports.RecentlyDeals = async (options) => {
     const locationService = new LocationService(options.locationRepository || new LocationRepository());
     const locationFormService = new LocationFormService(options.locationFormRepository || new LocationFormRepository());
     const coordinate = {
@@ -20,6 +20,24 @@ exports.basic = async (options) => {
         const locationList = await locationService.findIncluedArea(coordinate);
         return await locationFormService.findRecentlyDealsDistinct(coordinate, locationList);
     } catch (error) {
-        RESPONSE.errorCheckAndloggingThenThrow(error, RESPONSE.CONTROLLER_ERROR_NAME('basic'))
+        RESPONSE.errorCheckAndloggingThenThrow(error, RESPONSE.CONTROLLER_ERROR_NAME('RecentlyDeals'))
+    }
+}
+
+exports.ProviousOfRecentlyDeals = async (options) => {
+    const locationService = new LocationService(options.locationRepository || new LocationRepository());
+    const locationFormService = new LocationFormService(options.locationFormRepository || new LocationFormRepository());
+    const coordinate = {
+        min_x: options.body.bounds.min.x,
+        min_y: options.body.bounds.min.y,
+        max_x: options.body.bounds.max.x,
+        max_y: options.body.bounds.max.y
+    }
+
+    try {
+        const locationList = await locationService.findIncluedArea(coordinate);
+        return await locationFormService.findProviousOfRecentlyDeals(coordinate, locationList);
+    } catch (error) {
+        RESPONSE.errorCheckAndloggingThenThrow(error, RESPONSE.CONTROLLER_ERROR_NAME('ProviousOfRecentlyDeals'))
     }
 }

--- a/back/src/controllers/displayDealsController.js
+++ b/back/src/controllers/displayDealsController.js
@@ -1,9 +1,6 @@
 const LocationService = require('../application/service/location');
 const LocationFormService = require('../application/service/locationForm');
 
-const LocationRepository = require('../infrastructure/database/repositories/LocationRepositoryMysql');
-const LocationFormRepository = require('../infrastructure/database/repositories/LocationFormRepositoryMysql')
-
 const RESPONSE = require('../config/responseState');
 
 exports.RecentlyDeals = async (options) => {
@@ -25,8 +22,8 @@ exports.RecentlyDeals = async (options) => {
 }
 
 exports.ProviousOfRecentlyDeals = async (options) => {
-    const locationService = new LocationService(options.locationRepository || new LocationRepository());
-    const locationFormService = new LocationFormService(options.locationFormRepository || new LocationFormRepository());
+    const locationService = new LocationService(options.locationRepository);
+    const locationFormService = new LocationFormService(options.locationFormRepository);
     const coordinate = {
         min_x: options.body.bounds.min.x,
         min_y: options.body.bounds.min.y,

--- a/back/src/infrastructure/express/routes/index.js
+++ b/back/src/infrastructure/express/routes/index.js
@@ -4,10 +4,9 @@ const displayDealsController = require('../../../controllers/displayDealsControl
 const router = express.Router()
 
 router.post('/deal', async (req, res, next) => {
-    const result = await displayDealsController.basic({ body: req.body.mapState })
+    await displayDealsController.RecentlyDeals({ body: req.body.mapState })
+        .then((result) => res.json({ status: 200, data: result }))
         .catch((error) => next(error));
-
-    res.json({ status: 200, data: result });
 })
 
 module.exports = router;

--- a/back/src/infrastructure/express/routes/index.js
+++ b/back/src/infrastructure/express/routes/index.js
@@ -4,7 +4,13 @@ const displayDealsController = require('../../../controllers/displayDealsControl
 const router = express.Router()
 
 router.post('/deal', async (req, res, next) => {
-    await displayDealsController.RecentlyDeals({ body: req.body.mapState })
+    await displayDealsController.RecentlyDeals(Object.assign(app.locals.options, { body: req.body.mapState }))
+        .then((result) => res.json({ status: 200, data: result }))
+        .catch((error) => next(error));
+})
+
+router.post('/proviousDeal', async (req, res, next) => {
+    await displayDealsController.ProviousOfRecentlyDeals(Object.assign(app.locals.options, { body: req.body.mapState }))
         .then((result) => res.json({ status: 200, data: result }))
         .catch((error) => next(error));
 })

--- a/back/tests/integration/displayDealsController.spec.js
+++ b/back/tests/integration/displayDealsController.spec.js
@@ -30,7 +30,7 @@ describe('displayDealsController intgration module test', () => {
         };
 
         // when
-        const result = await displayDealsController.basic(updateOptions);
+        const result = await displayDealsController.RecentlyDeals(updateOptions);
 
         // then
         expect(result).toEqual([]);
@@ -69,7 +69,7 @@ describe('displayDealsController intgration module test', () => {
         };
 
         // when
-        const result = await displayDealsController.basic(updateOptions);
+        const result = await displayDealsController.RecentlyDeals(updateOptions);
         for (const deal of result) {
             delete deal.id;
         }

--- a/front/components/naverMap.vue
+++ b/front/components/naverMap.vue
@@ -1,60 +1,60 @@
-<template> 
-<div id='wrap' class='section'>   
-    <div id="naverMap"></div>    
-</div>
+<template>
+    <div id='wrap' class='section'>
+        <div id="naverMap"></div>
+    </div>
 </template>
 
 <script>
 export default {
-    props:{
+    props: {
         search: {},
     },
     name: 'hello',
     data() {
         return {
-            zoom_label:15,
-            map:null,
-            markers:[],
-            pause:false,
+            zoom_label: 15,
+            map: null,
+            markers: [],
+            pause: false,
         }
     },
-    computed:{
-        mapState(){
+    computed: {
+        mapState() {
             return this.$store.state.dealList.mapState;
         },
-        dealList(){
+        dealList() {
             return this.$store.state.dealList.dealList;
         },
-        options(){
+        options() {
             return this.$store.state.dealList.options;
         },
-        refreshMarker(){
+        refreshMarker() {
             return this.$store.state.dealList.refreshMarker;
         },
-        refreshList(){
-          return this.$store.state.dealList.refreshList;
+        refreshList() {
+            return this.$store.state.dealList.refreshList;
         }
     },
-    watch:{
-        search(newVal,oldVal){
-            if(newVal.length){
-                this.searchAddress(newVal,this.map,
-                this.getMapState);
+    watch: {
+        search(newVal, oldVal) {
+            if (newVal.length) {
+                this.searchAddress(newVal, this.map,
+                    this.getMapState);
             }
         },
-        dealList(newVal,oldVal){
+        dealList(newVal, oldVal) {
             console.log(this.options);
             console.log(this.map.getCenter());
-            this.setMarker(newVal,this.options);
+            this.setMarker(newVal, this.options);
         },
-        refreshMarker(newVal,oldVal){
+        refreshMarker(newVal, oldVal) {
             this.removeMarker();
-            this.setMarker(this.dealList,this.options);
+            this.setMarker(this.dealList, this.options);
         }
     },
-    methods:{
-        setContent(type=0){
-            if(type=0){
+    methods: {
+        setContent(type = 0) {
+            if (type = 0) {
                 return `
                         <div class="marker" alt="">
                         <div style="font-size:10px">
@@ -70,33 +70,33 @@ export default {
                        `
             }
         },
-        setAmount(amount){
-            let result='';
-            let a =parseInt(amount/10000);
-            let b = amount%10000;
-            if(a){
-                result+=`${a}억`
+        setAmount(amount) {
+            let result = '';
+            let a = parseInt(amount / 10000);
+            let b = amount % 10000;
+            if (a) {
+                result += `${a}억`
             }
-            if(b){
-              result+=`${b}만`
+            if (b) {
+                result += `${b}만`
             }
             return result
         },
-        async setMarker(dealList,options=null){
-            let visibleList=[];
-            const promises=dealList.map((deal, index)=>{
-                if(options){
-                    if( (!options.type[deal.house_type]) ||
-                        (options.date.min[0]>deal.deal_year||(options.date.min[0]==deal.deal_year&&options.date.min[1]>deal.deal_month)) ||
-                        (options.date.max[0]<deal.deal_year||(options.date.max[0]==deal.deal_year&&options.date.max[1]<deal.deal_month)) ||
-                        (options.amount[0]>deal.deal_amount||(options.amount[1]!=options.AMOUNTMAX&&options.amount[1]<deal.deal_amount))
-                    ){
-                        deal.visible=false;
+        async setMarker(dealList, options = null) {
+            let visibleList = [];
+            const promises = dealList.map((deal, index) => {
+                if (options) {
+                    if ((!options.type[deal.house_type]) ||
+                        (options.date.min[0] > deal.deal_year || (options.date.min[0] == deal.deal_year && options.date.min[1] > deal.deal_month)) ||
+                        (options.date.max[0] < deal.deal_year || (options.date.max[0] == deal.deal_year && options.date.max[1] < deal.deal_month)) ||
+                        (options.amount[0] > deal.deal_amount || (options.amount[1] != options.AMOUNTMAX && options.amount[1] < deal.deal_amount))
+                    ) {
+                        deal.visible = false;
                         return;
-                    }                    
+                    }
                 }
                 visibleList.push(index);
-                deal.visible=true;
+                deal.visible = true;
                 let contentText = `
                         <div class="marker" alt="">
                         <div style="font-size:10px; margin:0px">
@@ -111,76 +111,78 @@ export default {
                         </div>
                        `;
                 this.markers.push(new naver.maps.Marker({
-                position: new naver.maps.LatLng(deal.y,deal.x),
-                map: this.map,
-                icon: {
-                    content:contentText,
-                    //size: new naver.maps.Size(22, 35),
-                    //anchor: new naver.maps.Point(11, 35)
-                }
+                    position: new naver.maps.LatLng(deal.y, deal.x),
+                    map: this.map,
+                    icon: {
+                        content: contentText,
+                        //size: new naver.maps.Size(22, 35),
+                        //anchor: new naver.maps.Point(11, 35)
+                    }
                 }));
             })
 
             Promise.all(promises)
-            .then(()=>{
-                this.$store.dispatch('dealList/setVisibleDealsIndex',visibleList);
-                this.$store.dispatch('dealList/refreshList');
-                console.log(this.markers.length)
-            });
-            
-            
-        },
-        removeMarker(){
-            this.markers.forEach((marker)=>{
-                    marker.setMap(null);
-                    marker=null;
-            })
-            this.markers=[];
-        },
-        getMapState(){
-            if(!this.pause){
-                let map=this.map;
-                this.pause=true;
-                let oldPoint={x:map.getCenter().x,y:map.getCenter().y};
-                setTimeout(this.delaySetMapState,400,map,oldPoint);
-            }
-        },
-        delaySetMapState(map,oldPoint){
-
-            let newPoint={x:this.map.getCenter().x,y:this.map.getCenter().y};
-            if(oldPoint.x==newPoint.x && oldPoint.y==newPoint.y){
-                this.removeMarker();
-                this.$store.dispatch('dealList/setDeals',{
-                        point:{x:map.getCenter().x,y:map.getCenter().y},
-                        bounds:{max:map.getBounds()._max,min:map.getBounds()._min},
-                        Zoom:map.getZoom(),
+                .then(() => {
+                    this.$store.dispatch('dealList/setVisibleDealsIndex', visibleList);
+                    this.$store.dispatch('dealList/refreshList');
+                    console.log(this.markers.length)
                 });
-                setTimeout(()=>{
-                    this.pause=false;
-                    if(this.mapState.point.x!=map.getCenter().x||this.mapState.point.y!=map.getCenter().y){
-                        this.getMapState();
-                    }
-                },500)
-            }else{
-                setTimeout(this.delaySetMapState,400,map,newPoint);
+
+
+        },
+        removeMarker() {
+            this.markers.forEach((marker) => {
+                marker.setMap(null);
+                marker = null;
+            })
+            this.markers = [];
+        },
+        getMapState() {
+            if (!this.pause) {
+                this.pause = true;
+                let map = this.map;
+                let oldPoint = { x: map.getCenter().x, y: map.getCenter().y };
+                setTimeout(this.delaySetMapState, 400, map, oldPoint);
             }
         },
-        searchAddress(address,map) {
+        delaySetMapState(map, oldPoint) {
+
+            let newPoint = { x: this.map.getCenter().x, y: this.map.getCenter().y };
+            if (oldPoint.x == newPoint.x && oldPoint.y == newPoint.y) {
+                this.removeMarker();
+                this.$store.dispatch('dealList/setDeals', {
+                    point: { x: map.getCenter().x, y: map.getCenter().y },
+                    bounds: { max: map.getBounds()._max, min: map.getBounds()._min },
+                    Zoom: map.getZoom(),
+                }).then(() => {
+                    setTimeout(() => {
+                        this.pause = false;
+                        if (this.mapState.point.x != map.getCenter().x || this.mapState.point.y != map.getCenter().y) {
+                            this.getMapState();
+                        }
+                    }, 500)
+                })
+
+            } else {
+                setTimeout(this.delaySetMapState, 400, map, newPoint);
+            }
+        },
+        searchAddress(address, map) {
             naver.maps.Service.geocode({
                 query: address
-            }, function(status, response) {
+            }, function (status, response) {
                 if (status === naver.maps.Service.Status.ERROR) {
-                if (!address) {
-                    return alert('Geocode Error, Please check address');
-                }
-                return alert('Geocode Error, address:' + address);
+                    if (!address) {
+                        return alert('Geocode Error, Please check address');
+                    }
+                    return alert('Geocode Error, address:' + address);
                 }
                 if (response.v2.meta.totalCount === 0) {
-                return alert('No result.');
+                    return alert('No result.');
                 }
 
                 let item = response.v2.addresses[0];
-                console.log("searchAddress:",response.v2.addresses);
+                console.log("searchAddress:", response.v2.addresses);
                 let point = new naver.maps.Point(item.x, item.y);
 
                 map.setCenter(point);
@@ -190,24 +192,24 @@ export default {
     },
     mounted() {
         let map = null
-        var zoom_label=this.zoom_label;
+        var zoom_label = this.zoom_label;
 
-        initMap(zoom_label,this.getMapState);
-        this.map=map;
+        initMap(zoom_label, this.getMapState);
+        this.map = map;
 
-        function initMap(zoom_label,getMapState) {
+        function initMap(zoom_label, getMapState) {
             map = new naver.maps.Map(document.getElementById('naverMap'), {
-                    center: new naver.maps.LatLng(37.3595704, 127.105399),
-                    zoom: zoom_label,
-                    zoomControl: false,
-                    zoomControlOptions: {position: naver.maps.Position.RIGHT_TOP},
-                    mapTypeId: naver.maps.MapTypeId.NORMAL
-                });
+                center: new naver.maps.LatLng(37.3595704, 127.105399),
+                zoom: zoom_label,
+                zoomControl: false,
+                zoomControlOptions: { position: naver.maps.Position.RIGHT_TOP },
+                mapTypeId: naver.maps.MapTypeId.NORMAL
+            });
 
-            naver.maps.Event.addListener(map, "center_changed", function() {
-                    window.setTimeout(function() {
-                        getMapState();
-                    }, 100);
+            naver.maps.Event.addListener(map, "center_changed", function () {
+                window.setTimeout(function () {
+                    getMapState();
+                }, 100);
             });
 
         } // end_mount
@@ -218,31 +220,33 @@ export default {
 
 
 <style>
-    #naverMap {
-        height: 100vh;
-        min-height: 100vh;
-        width: 100%;
-    }
-    .marker{
-        overflow: hidden;
-        padding:0px 0px 0px 0px;
-        position:absolute;
-        background-color: #ffffffcc;
-        border: 2px solid #1bf;
-        padding: 0.5rem;
-        line-height: 1rem;
-        border-radius: 0.5rem;
-        width: 55px; 
-        height: 25px;
-    }
-    .marker:hover{
-        position:absolute;
-        background-color: #ffffffcc;
-        border: 2px solid rgb(253, 78, 78);
-        padding: 0.5rem;
-        line-height: 1rem;
-        border-radius: 0.5rem;
-        width: 100px; 
-        height: 100px;
-    }
+#naverMap {
+    height: 100vh;
+    min-height: 100vh;
+    width: 100%;
+}
+
+.marker {
+    overflow: hidden;
+    padding: 0px 0px 0px 0px;
+    position: absolute;
+    background-color: #ffffffcc;
+    border: 2px solid #1bf;
+    padding: 0.5rem;
+    line-height: 1rem;
+    border-radius: 0.5rem;
+    width: 55px;
+    height: 25px;
+}
+
+.marker:hover {
+    position: absolute;
+    background-color: #ffffffcc;
+    border: 2px solid rgb(253, 78, 78);
+    padding: 0.5rem;
+    line-height: 1rem;
+    border-radius: 0.5rem;
+    width: 100px;
+    height: 100px;
+}
 </style>

--- a/front/layouts/default.vue
+++ b/front/layouts/default.vue
@@ -1,34 +1,33 @@
 <template>
   <div>
-    
-  <nuxt/>
+
+    <nuxt />
   </div>
 </template>
 
 <script>
-  
-  export default {
-    components: {
-      
-    },
-    head(){
-          return{
-              title: 'map test',
-              meta:[
-                  {name:"viewport",content:"width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no"},
-                  {charset:"UTF-8"},
-                  {'http-equiv':"X-UA-Compatible", content:"IE=edge"}
-              ],
-              script:[
-                  {type:"text/javascript",src:"https://openapi.map.naver.com/openapi/v3/maps.js?ncpClientId=yrmv6xu634&submodules=geocoder",defer:true},
-                  {src:"https://cdn.jsdelivr.net/npm/chart.js"}
 
-              ],
-          }
-      }
+export default {
+  components: {
+
+  },
+  head() {
+    return {
+      title: 'map test',
+      meta: [
+        { name: "viewport", content: "width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no" },
+        { charset: "UTF-8" },
+        { 'http-equiv': "X-UA-Compatible", content: "IE=edge" }
+      ],
+      script: [
+        { type: "text/javascript", src: "https://openapi.map.naver.com/openapi/v3/maps.js?ncpClientId=optwmz6a2n&submodules=geocoder", defer: true },
+        { src: "https://cdn.jsdelivr.net/npm/chart.js" }
+
+      ],
+    }
   }
+}
 </script>
 
 <style>
-
 </style>

--- a/front/store/dealList.js
+++ b/front/store/dealList.js
@@ -1,89 +1,89 @@
 export const state = () => ({
-    dealList: [],
-    visibleDealsIndex:[],
-    visible:[],
-    mapState: null,
-    options:{
-      date:{
-        min:[new Date().getFullYear(),new Date().getMonth()+1,-1,0],
-        max:[new Date().getFullYear(),new Date().getMonth()+1,0,0]
-      },
-      type: {
-        '오피스텔':true,
-        '아파트':true,
-        '연립다세대':true,
-      },
-      amount:[0,1000000],//1=>1만원
-      AMOUNTMAX:500000,
+  dealList: [],
+  visibleDealsIndex: [],
+  visible: [],
+  mapState: null,
+  options: {
+    date: {
+      min: [new Date().getFullYear(), new Date().getMonth() + 1, -1, 0],
+      max: [new Date().getFullYear(), new Date().getMonth() + 1, 0, 0]
     },
-    refreshMarker:true,
-    refreshList:true,
-  });
-  
-  export const mutations = {
-    setDeals(state,payload) {
-      state.dealList.splice(0);
-      state.dealList=payload;
+    type: {
+      '오피스텔': true,
+      '아파트': true,
+      '연립다세대': true,
     },
-    setMapState(state,payload){
-        state.mapState=payload;
-    },
-    setDate(state,date){
-      state.options.date.min=date.min;
-      state.options.date.max=date.max;
-      state.options=state.options;
+    amount: [0, 1000000],//1=>1만원
+    AMOUNTMAX: 500000,
+  },
+  refreshMarker: true,
+  refreshList: true,
+});
 
-      state.refreshMarker=!state.refreshMarker;
-    },
-    changeType(state,typeName){
-      state.options.type[typeName]=!state.options.type[typeName];
-      state.options=state.options;
+export const mutations = {
+  setDeals(state, payload) {
+    state.dealList.splice(0);
+    state.dealList = payload;
+  },
+  setMapState(state, payload) {
+    state.mapState = payload;
+  },
+  setDate(state, date) {
+    state.options.date.min = date.min;
+    state.options.date.max = date.max;
+    state.options = state.options;
 
-      state.refreshMarker=!state.refreshMarker;
-    },
-    setAmount(state,amount){
-      state.options.amount=amount;
-      state.refreshMarker=!state.refreshMarker;
-    },
-    refreshList(state,payload){
-      state.refreshList=!state.refreshList;
-    },
-    setVisibleDealsIndex(state,payload){
-      state.visibleDealsIndex.splice(0);
-      state.visibleDealsIndex=payload;
-    }
-  };
+    state.refreshMarker = !state.refreshMarker;
+  },
+  changeType(state, typeName) {
+    state.options.type[typeName] = !state.options.type[typeName];
+    state.options = state.options;
 
-  export const actions = {
-    setDeals({commit},payload){
-        this.$axios.post('http://127.0.0.1:7000/deal',{
-            mapState:payload
-        })
-        .then(async (res)=>{
-            commit('setDeals',res.data.data);
-            commit('setMapState',payload);
-        })
-        .catch((error)=>{
-            console.error(error);
-            commit('setMapState',payload);
-        })
-    },
-    setMapState({commit},payload){
-        commit('setMapState',payload);
-    },
-    setDate({commit},payload){
-      commit('setDate',payload);
-    },
-    changeType({commit},payload){
-      commit('changeType',payload);
-    },
-    setAmount({commit},payload){
-      commit('setAmount',payload);
-    },
-    refreshList({commit},payload){
-      commit('refreshList',payload);
-    },
-    setVisibleDealsIndex({commit},payload){
-      commit('setVisibleDealsIndex',payload);
-    }
+    state.refreshMarker = !state.refreshMarker;
+  },
+  setAmount(state, amount) {
+    state.options.amount = amount;
+    state.refreshMarker = !state.refreshMarker;
+  },
+  refreshList(state, payload) {
+    state.refreshList = !state.refreshList;
+  },
+  setVisibleDealsIndex(state, payload) {
+    state.visibleDealsIndex.splice(0);
+    state.visibleDealsIndex = payload;
   }
+};
+
+export const actions = {
+  async setDeals({ commit }, payload) {
+    await this.$axios.post('http://127.0.0.1:7000/deal', {
+      mapState: payload
+    })
+      .then(async (res) => {
+        commit('setDeals', res.data.data);
+        commit('setMapState', payload);
+      })
+      .catch((error) => {
+        console.error(error);
+        commit('setMapState', payload);
+      })
+  },
+  setMapState({ commit }, payload) {
+    commit('setMapState', payload);
+  },
+  setDate({ commit }, payload) {
+    commit('setDate', payload);
+  },
+  changeType({ commit }, payload) {
+    commit('changeType', payload);
+  },
+  setAmount({ commit }, payload) {
+    commit('setAmount', payload);
+  },
+  refreshList({ commit }, payload) {
+    commit('refreshList', payload);
+  },
+  setVisibleDealsIndex({ commit }, payload) {
+    commit('setVisibleDealsIndex', payload);
+  }
+}


### PR DESCRIPTION
1.가장 최근 거래된 매물과 직전 거래 정보를 제공하는 서비스 추가
 - 직전 거래 정보를 검색하기 위해 많은 DB 검색 시간이 소요되어 검색한 정보를 재활용 하도록 작성
 - 글로벌 변수를 생성하여 검색한 정보를 저장하여 DB검색에 대한 부하를 최소화

 - 하지만 기간 설정에 따른 최근 거래 매물에 대한 검색 내용을 제공할 수 없는 제약 조건 발생(query소요시간 약4초)

 